### PR TITLE
sloppy glow keybind implementation

### DIFF
--- a/src/Hacks/esp.cpp
+++ b/src/Hacks/esp.cpp
@@ -25,6 +25,8 @@ ImColor Settings::ESP::grenade_color = ImColor(224, 22, 22, 255);
 ImColor Settings::ESP::molotov_color = ImColor(224, 22, 22, 255);
 ImColor Settings::ESP::Skeleton::color = ImColor(255, 255, 255, 255);
 bool Settings::ESP::Glow::enabled = false;
+bool Settings::ESP::Glow::key_enabled = false;
+ButtonCode_t Settings::ESP::Glow::key = ButtonCode_t::KEY_CAPSLOCK;
 ImColor Settings::ESP::Glow::ally_color = ImColor(0, 50, 200, 200);
 ImColor Settings::ESP::Glow::enemy_color = ImColor(200, 0, 50, 200);
 ImColor Settings::ESP::Glow::enemy_visible_color = ImColor(200, 200, 50, 200);
@@ -964,6 +966,10 @@ void ESP::DrawGlow()
 	C_BasePlayer* localplayer = (C_BasePlayer*)entitylist->GetClientEntity(engine->GetLocalPlayer());
 	if (!localplayer)
 		return;
+
+	if (Settings::ESP::Glow::key_enabled)
+		if(!input->IsButtonDown(Settings::ESP::Glow::key)) 
+			return;
 
 	for (int i = 0; i < glowmanager->m_GlowObjectDefinitions.Count(); i++)
 	{

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -942,6 +942,10 @@ void VisualsTab()
 					ImGui::Checkbox("Entity Glow", &Settings::ESP::Glow::enabled);
 					if (ImGui::IsItemHovered())
 						ImGui::SetTooltip("Show a glow around entities");
+					ImGui::ItemSize(ImVec2(0.0f, 0.0f), 0.0f);
+					ImGui::Checkbox("Glow key", &Settings::ESP::Glow::key_enabled);
+					if (ImGui::IsItemHovered())
+						ImGui::SetTooltip("Activate keybind for Glow around entities");
 				}
 				ImGui::NextColumn();
 				{
@@ -954,6 +958,7 @@ void VisualsTab()
 					ImGui::Checkbox("Hostages", &Settings::ESP::Filters::hostages);
 					if (ImGui::IsItemHovered())
 						ImGui::SetTooltip("Show hostages");
+					UI::KeyBindButton(&Settings::ESP::Glow::key);
 				}
 				ImGui::Columns(1);
 				ImGui::EndChild();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -178,6 +178,8 @@ void Settings::LoadDefaultsOrSave(std::string path)
 	LoadUIColor(settings["ESP"]["grenade_color"], Settings::ESP::grenade_color);
 	LoadUIColor(settings["ESP"]["molotov_color"], Settings::ESP::molotov_color);
 	settings["ESP"]["Glow"]["enabled"] = Settings::ESP::Glow::enabled;
+	settings["ESP"]["Glow"]["key_enabled"] = Settings::ESP::Glow::key_enabled;
+	settings["ESP"]["Glow"]["key"] = Util::GetButtonName(Settings::ESP::Glow::key);
 	LoadUIColor(settings["ESP"]["Glow"]["ally_color"], Settings::ESP::Glow::ally_color);
 	LoadUIColor(settings["ESP"]["Glow"]["enemy_color"], Settings::ESP::Glow::enemy_color);
 	LoadUIColor(settings["ESP"]["Glow"]["enemy_visible_color"], Settings::ESP::Glow::enemy_visible_color);
@@ -501,6 +503,8 @@ void Settings::LoadConfig(std::string path)
 	GetVal(settings["ESP"]["grenade_color"], &Settings::ESP::grenade_color);
 	GetVal(settings["ESP"]["molotov_color"], &Settings::ESP::molotov_color);
 	GetVal(settings["ESP"]["Glow"]["enabled"], &Settings::ESP::Glow::enabled);
+	GetVal(settings["ESP"]["Glow"]["key_enabled"], &Settings::ESP::Glow::key_enabled);
+	GetButtonCode(settings["ESP"]["Glow"]["key"], &Settings::ESP::Glow::key);
 	GetVal(settings["ESP"]["Glow"]["ally_color"], &Settings::ESP::Glow::ally_color);
 	GetVal(settings["ESP"]["Glow"]["enemy_color"], &Settings::ESP::Glow::enemy_color);
 	GetVal(settings["ESP"]["Glow"]["enemy_visible_color"], &Settings::ESP::Glow::enemy_visible_color);

--- a/src/settings.h
+++ b/src/settings.h
@@ -392,6 +392,8 @@ namespace Settings
 		namespace Glow
 		{
 			extern bool enabled;
+			extern bool key_enabled;
+			extern ButtonCode_t key;
 			extern ImColor ally_color;
 			extern ImColor enemy_color;
 			extern ImColor enemy_visible_color;


### PR DESCRIPTION
Thanks to cutblack I was able to add a checkbox and a keybind for the glow in the interface and settings, it's probably a sloppy integration since I havn't really ever coded anything substantial and don't code in C++ so anyone fell free to change it or even delete my changes if it's too poorly implemented or useless, seriously. Epecially since I don't if I'm not going to use it myself because I wanted to make it a toggle but I don't know at all how to do it (I had already tried in the old UI but wasn't able to).