### PR TITLE
Fix glow esp flickering

### DIFF
--- a/src/Hacks/esp.cpp
+++ b/src/Hacks/esp.cpp
@@ -1147,7 +1147,7 @@ void ESP::Paint()
 		ESP::DrawScope();
 }
 
-void ESP::BeginFrame(float frameTime)
+void ESP::DrawModelExecute(void* thisptr, void* context, void *state, const ModelRenderInfo_t &pInfo, matrix3x4_t *pCustomBoneToWorld)
 {
 	if (!Settings::ESP::enabled)
 		return;

--- a/src/Hacks/esp.h
+++ b/src/Hacks/esp.h
@@ -37,7 +37,7 @@ namespace ESP
 	void DrawGlow();
 	void DrawScope();
 
-	void BeginFrame(float frameTime);
+	void DrawModelExecute(void* thisptr, void* context, void *state, const ModelRenderInfo_t &pInfo, matrix3x4_t *pCustomBoneToWorld);
 	bool PrePaintTraverse(VPANEL vgui_panel, bool force_repaint, bool allow_force);
 	void Paint();
 	void EmitSound(int iEntIndex, const char *pSample);

--- a/src/Hooks/BeginFrame.cpp
+++ b/src/Hooks/BeginFrame.cpp
@@ -2,7 +2,6 @@
 
 void Hooks::BeginFrame(void* thisptr, float frameTime)
 {
-	ESP::BeginFrame(frameTime);
 	ClanTagChanger::BeginFrame(frameTime);
 	NameChanger::BeginFrame(frameTime);
 	NameStealer::BeginFrame(frameTime);

--- a/src/Hooks/DrawModelExecute.cpp
+++ b/src/Hooks/DrawModelExecute.cpp
@@ -5,7 +5,10 @@ void Hooks::DrawModelExecute(void* thisptr, void* context, void *state, const Mo
 	modelRender_vmt->ReleaseVMT();
 
 	if (!Settings::ScreenshotCleaner::enabled || !engine->IsTakingScreenshot())
+	{
 		Chams::DrawModelExecute(thisptr, context, state, pInfo, pCustomBoneToWorld);
+		ESP::DrawModelExecute(thisptr, context, state, pInfo, pCustomBoneToWorld);
+	}
 
 	modelRender->DrawModelExecute(context, state, pInfo, pCustomBoneToWorld);
 	modelRender->ForcedMaterialOverride(NULL);


### PR DESCRIPTION
The reason for this is glow internally calls ForcedMaterialOverride()
which should be called in DrawModelExecute().

[https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/client/glow_outline_effect.cpp#L161-L162](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/client/glow_outline_effect.cpp#L161-L162)