### PR TITLE
Fix a bunch of memory leaks

### DIFF
--- a/src/Hacks/esp.cpp
+++ b/src/Hacks/esp.cpp
@@ -1,3 +1,5 @@
+#include <iomanip>
+
 #include "esp.h"
 #include "../Utils/skins.h"
 
@@ -670,10 +672,10 @@ void ESP::DrawPlantedBomb(C_PlantedC4* bomb)
 	ImColor color = bomb->GetBombDefuser() != -1 || bomb->IsBombDefused() ? Settings::ESP::bomb_defusing_color : Settings::ESP::bomb_color;
 
 	float bombTimer = bomb->GetBombTime() - globalvars->curtime;
-	std::string displayText;
+	std::stringstream displayText;
 	if (bomb->IsBombDefused() || !bomb->IsBombTicking() || bombTimer <= 0.f)
 	{
-			displayText = "Bomb";
+			displayText << "Bomb";
 	}
 	else
 	{
@@ -690,12 +692,10 @@ void ESP::DrawPlantedBomb(C_PlantedC4* bomb)
 
 		float damage = std::max((int)ceilf(GetArmourHealth(flDamage, localplayer->GetArmor())), 0);
 
-		char* buffer;
-		asprintf(&buffer, "Bomb: %.1f, damage: %d", bombTimer, (int) damage);
-		displayText = std::string(buffer);
+		displayText << "Bomb: " << std::fixed << std::showpoint << std::setprecision(1) << bombTimer << ", damage: " << (int) damage;
 	}
 
-	DrawEntity(bomb, displayText.c_str(), Color::FromImColor(color));
+	DrawEntity(bomb, displayText.str().c_str(), Color::FromImColor(color));
 }
 
 void ESP::DrawDefuseKit(C_BaseEntity* defuser)

--- a/src/Hacks/hitmarkers.cpp
+++ b/src/Hacks/hitmarkers.cpp
@@ -66,14 +66,13 @@ void Hitmarkers::Paint()
 				height / 2 - Settings::ESP::Hitmarker::size - textHeight * i + 4
 		);
 
-		char* buff;
 		int damage = damages[i].first;
-		asprintf(&buff, "-%d", damage);
+		std::string damageStr = '-' + std::to_string(damage);
 
 		color.a = Color::FromImColor(Settings::ESP::Hitmarker::color).a;
 		color.a = std::min(color.a, (int)(hitDiff * color.a / duration * 2));
 
-		Draw::Text(pos, buff, esp_font, color);
+		Draw::Text(pos, damageStr.c_str(), esp_font, color);
 	}
 }
 

--- a/src/Hacks/namechanger.cpp
+++ b/src/Hacks/namechanger.cpp
@@ -1,6 +1,6 @@
 #include "namechanger.h"
 
-char* NameChanger::origName = strdup("");
+std::string NameChanger::origName = "";
 int NameChanger::changes = -1;
 NC_Type NameChanger::type = NC_NORMAL;
 
@@ -24,16 +24,14 @@ enum class Colors
 	ORANGE,
 };
 
-char* NameChanger::GetName()
+std::string NameChanger::GetName()
 {
 	IEngineClient::player_info_t playerInfo;
 	engine->GetPlayerInfo(engine->GetLocalPlayer(), &playerInfo);
-	char* buff;
-	asprintf(&buff, "%s", playerInfo.name);
-	return buff;
+	return std::string(playerInfo.name);
 }
 
-const char* Rainbowify(char* name)
+std::string Rainbowify(const std::string& name)
 {
 	std::string base = " \x01\x0B";
 	std::vector<char> rainbow = {
@@ -45,28 +43,28 @@ const char* Rainbowify(char* name)
 			(char)(Colors::PURPLE),
 	};
 
-	unsigned int color = 0;
-	for (char* it = name; *it; it++)
+	size_t color = 0;
+	for (char c : name)
 	{
 		if (color > rainbow.size() - 1)
 			color = 0;
 		base.push_back(rainbow[color]);
-		base.push_back(*it);
+		base.push_back(c);
 		color++;
 	}
 
 	base.append("\230");
-	return base.c_str();
+	return base;
 }
 
-const char* Colorize(char* name, Colors color = Colors::LIGHT_RED)
+std::string Colorize(const std::string& name, Colors color = Colors::LIGHT_RED)
 {
 	// TODO: Add color customization
 	std::string res = " \x01\x0B";
 	res += (char)(color);
 	res.append(name);
 	res.append("\230");
-	return res.c_str();
+	return res;
 }
 
 void NameChanger::BeginFrame(float frameTime)
@@ -94,10 +92,10 @@ void NameChanger::BeginFrame(float frameTime)
 				SetName(Util::PadStringRight("\230AIMTUX.NET", strlen("\230AIMTUX.NET") + RandomInt(10, 50)));
 				break;
 			case NC_RAINBOW:
-				SetName(Util::PadStringRight(Rainbowify(origName), strlen(origName) + RandomInt(10, 50)));
+				SetName(Util::PadStringRight(Rainbowify(origName), origName.size() + RandomInt(10, 50)));
 				break;
 			case NC_SOLID:
-				SetName(Util::PadStringRight(Colorize(origName), strlen(origName) + RandomInt(10, 50)));
+				SetName(Util::PadStringRight(Colorize(origName), origName.size() + RandomInt(10, 50)));
 				break;
 		}
 

--- a/src/Hacks/namechanger.h
+++ b/src/Hacks/namechanger.h
@@ -13,9 +13,9 @@ namespace NameChanger
 {
 	extern int changes;
 	extern NC_Type type;
-	extern char* origName;
+	extern std::string origName;
 
-	char* GetName();
+	std::string GetName();
 	void BeginFrame(float frameTime);
 	void SetName(const char* name);
 };

--- a/src/Utils/netvarmanager.cpp
+++ b/src/Utils/netvarmanager.cpp
@@ -129,8 +129,7 @@ void NetVarManager::dumpNetvars()
 
 	getcwd(cwd, sizeof(cwd));
 
-	char* netvarsPath;
-	asprintf(&netvarsPath, "%s/netvars.txt", cwd);
+	std::string netvarsPath = std::string(cwd) + "/netvars.txt";
 
 	std::ofstream(netvarsPath) << ss.str();
 }

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -460,14 +460,14 @@ void AimbotTab()
 				const bool item_selected = (it.first == (int)  current_weapon);
 				ImGui::PushID(it.first);
 
-					char* formattedName;
+					std::string formattedName;
 					char changeIndicator = ' ';
 					bool isChanged = Settings::Aimbot::weapons.find((ItemDefinitionIndex) it.first) != Settings::Aimbot::weapons.end();
 					if (!isDefault && isChanged)
 						changeIndicator = '*';
-					asprintf(&formattedName, "%c %s", changeIndicator, it.second);
+					formattedName = changeIndicator + std::string(it.second);
 
-					if (ImGui::Selectable(formattedName, item_selected))
+					if (ImGui::Selectable(formattedName.c_str(), item_selected))
 					{
 						current_weapon = (ItemDefinitionIndex ) it.first;
 
@@ -2170,8 +2170,7 @@ void PlayerListWindow()
 
 				for (auto it : players[(TeamID) team])
 				{
-					char* id;
-					asprintf(&id, "%d", it);
+					std::string id = std::to_string(it);
 
 					IEngineClient::player_info_t entityInformation;
 					engine->GetPlayerInfo(it, &entityInformation);
@@ -2181,7 +2180,7 @@ void PlayerListWindow()
 
 					ImGui::Separator();
 
-					if (ImGui::Selectable(id, it == currentPlayer, ImGuiSelectableFlags_SpanAllColumns))
+					if (ImGui::Selectable(id.c_str(), it == currentPlayer, ImGuiSelectableFlags_SpanAllColumns))
 						currentPlayer = it;
 					ImGui::NextColumn();
 

--- a/src/interfaces.cpp
+++ b/src/interfaces.cpp
@@ -54,8 +54,7 @@ void Interfaces::dumpInterfaces()
 
 	getcwd(cwd, sizeof(cwd));
 
-	char* interfacesPath;
-	asprintf(&interfacesPath, "%s/interfaces.txt", cwd);
+	std::string interfacesPath = std::string(cwd) + "/interfaces.txt";
 
 	std::ofstream(interfacesPath) << ss.str();
 }


### PR DESCRIPTION
* ESP::DrawPlantedBomb() used 24-23 bytes per bomb tick
* Hitmarkers::Paint() used a few bytes per hit
* NameChanger::GetName() used a bunch of bytes each call
* NetVarManager::dumpNetvars() used a bunch of bytes once
* AimbotTab() used a bunch of bytes each call
* PlayerListWindow() used a few bytes each call
* Interfaces::dumpInterfaces() used a bunch of bytes once

asprintf(3):
> DESCRIPTION
>        The  functions asprintf() and vasprintf() are analogs of sprintf(3) and
>        vsprintf(3), except that they allocate a string large  enough  to  hold
>        the  output  including  the  terminating null byte ('\0'), and return a
>        pointer to it via the first argument.  **This pointer should be passed to
>        free(3) to release the allocated storage when it is no longer needed**.