### PR TITLE
Use generic RecvPropHook class for m_nSequence hook.

### DIFF
--- a/src/AimTux.cpp
+++ b/src/AimTux.cpp
@@ -84,7 +84,10 @@ int __attribute__((constructor)) aimtux_init()
 
 	eventListener = new EventListener({ "cs_game_disconnected", "player_connect_full", "player_death", "player_hurt" });
 
-	SkinChanger::HookCBaseViewModel();
+	if (ModSupport::current_mod != ModType::CSCO && Hooker::HookRecvProp("CBaseViewModel", "m_nSequence", SkinChanger::sequenceHook))
+	{
+		SkinChanger::sequenceHook->SetProxyFunction((RecvVarProxyFn) SkinChanger::SetViewModelSequence);
+	}
 
 	NetVarManager::DumpNetvars();
 	Offsets::GetOffsets();
@@ -117,8 +120,6 @@ void __attribute__((destructor)) aimtux_shutdown()
 	soundVMT->ReleaseVMT();
 
 	delete eventListener;
-
-	SkinChanger::UnhookCBaseViewModel();
 
 	*bSendPacket = true;
 

--- a/src/Hacks/skinchanger.h
+++ b/src/Hacks/skinchanger.h
@@ -5,6 +5,8 @@
 #include "../settings.h"
 #include "../modsupport.h"
 
+class RecvPropHook;
+
 extern GetLocalClientFn GetLocalClient;
 
 extern std::unordered_map<std::string, std::string> killIcons;
@@ -12,13 +14,12 @@ extern std::unordered_map<std::string, std::string> killIcons;
 namespace SkinChanger
 {
 	extern bool forceFullUpdate;
+	extern std::unique_ptr<RecvPropHook> sequenceHook;
 
 	void FrameStageNotifyWeapons(ClientFrameStage_t stage);
 	void FrameStageNotifyGloves(ClientFrameStage_t stage);
 	void FireEventClientSide(IGameEvent* event);
 	void SetViewModelSequence(const CRecvProxyData *pDataConst, void *pStruct, void *pOut);
-	void HookCBaseViewModel();
-	void UnhookCBaseViewModel();
 };
 
 extern RecvVarProxyFn fnSequenceProxyFn;

--- a/src/Utils/recvproxyhook.h
+++ b/src/Utils/recvproxyhook.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "../SDK/SDK.h"
+
+// credits: emskye96
+class RecvPropHook
+{
+	private:
+		RecvProp* target_property;
+		RecvVarProxyFn original_proxy_fn;
+	public:
+		RecvPropHook(RecvProp* target_property)
+		{
+			this->target_property = target_property;
+			this->original_proxy_fn = target_property->m_ProxyFn;
+		}
+
+		~RecvPropHook()
+		{
+			target_property->m_ProxyFn = this->original_proxy_fn;
+		}
+
+		RecvVarProxyFn GetOriginalFunction()
+		{
+			return this->original_proxy_fn;
+		}
+
+		void SetProxyFunction(RecvVarProxyFn user_proxy_fn)
+		{
+			target_property->m_ProxyFn = user_proxy_fn;
+		}
+};

--- a/src/hooker.cpp
+++ b/src/hooker.cpp
@@ -78,6 +78,34 @@ void Hooker::InitializeVMHooks()
 	soundVMT = new VMT(sound);
 }
 
+bool Hooker::HookRecvProp(const char* className, const char* propertyName, std::unique_ptr<RecvPropHook>& recvPropHook)
+{
+	// FIXME: Does not search recursively.. yet.
+	for (ClientClass* pClass = client->GetAllClasses(); pClass; pClass = pClass->m_pNext)
+	{
+		if (strcmp(pClass->m_pNetworkName, className) == 0)
+		{
+			RecvTable* pClassTable = pClass->m_pRecvTable;
+
+			for (int nIndex = 0; nIndex < pClassTable->m_nProps; nIndex++)
+			{
+				RecvProp* pProp = &pClassTable->m_pProps[nIndex];
+
+				if (!pProp || strcmp(pProp->m_pVarName, propertyName) != 0)
+					continue;
+
+				recvPropHook = std::make_unique<RecvPropHook>(pProp);
+
+				return true;
+			}
+
+			break;
+		}
+	}
+
+	return false;
+}
+
 void Hooker::FindIClientMode()
 {
 	uintptr_t hudprocessinput = reinterpret_cast<uintptr_t>(getvtable(client)[10]);

--- a/src/hooker.h
+++ b/src/hooker.h
@@ -54,10 +54,12 @@
 #define GETCSWPNDATA_SIGNATURE "\x55\x48\x89\xE5\x0F\xB7\xBF\xD4\x3A"
 #define GETCSWPNDATA_MASK "xxxxxxxxx"
 
+#include <memory>
 #include <unordered_map>
 #include <sys/mman.h>
 #include <link.h>
 #include "Utils/patternfinder.h"
+#include "Utils/recvproxyhook.h"
 #include "SDK/SDK.h"
 #include "Utils/vmt.h"
 #include "Utils/util.h"
@@ -69,6 +71,7 @@ namespace Hooker
 	std::unordered_map<const char*, uintptr_t> GetProcessLibraries();
 	uintptr_t GetLibraryAddress(const char* moduleName);
 	void InitializeVMHooks();
+	bool HookRecvProp(const char* className, const char* propertyName, std::unique_ptr<RecvPropHook>& recvPropHook);
 	void FindIClientMode();
 	void FindGlobalVars();
 	void FindCInput();


### PR DESCRIPTION
Should make any future hooking of NetVar proxy functions a lot easier. The `HookRecvProp` function in the hooker file doesn't recurse child tables yet - I'm not really sure how to do it with the NetVar manager that AimTux uses. Most code was adapted from [Chameleon NG](https://github.com/emskye96/chameleon-ng/blob/master/src/Chameleon.cpp#L79-L85).

I wasn't really sure where to put everything so maybe some things will need moving around or cleaning up.