### PR TITLE
Add Timeout Vote Spammer

### DIFF
--- a/src/Hacks/spammer.cpp
+++ b/src/Hacks/spammer.cpp
@@ -6,6 +6,7 @@ bool Settings::Spammer::KillSpammer::enabled = false;
 bool Settings::Spammer::KillSpammer::sayTeam = false;
 char* Settings::Spammer::KillSpammer::message = strdup("$nick just got OWNED by AimTux!!");
 bool Settings::Spammer::RadioSpammer::enabled = false;
+bool Settings::Spammer::TimeoutSpammer::enabled = false;
 std::vector<std::string> Settings::Spammer::NormalSpammer::messages = {
 		"AimTux owns me and all",
 		"Your Windows p2c sucks my AimTux dry",
@@ -33,6 +34,9 @@ void Spammer::BeginFrame(float frameTime)
 	// Grab the current time in milliseconds
 	long currentTime_ms = Util::GetEpochTime();
 	static long timeStamp = currentTime_ms;
+
+	if (Settings::Spammer::TimeoutSpammer::enabled)
+		engine->ExecuteClientCmd("callvote starttimeout");
 
 	if (currentTime_ms - timeStamp < 850)
 		return;

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -1212,6 +1212,8 @@ void MiscTab()
 
 			ImGui::Columns(1);
 			ImGui::Checkbox("Radio Commands", &Settings::Spammer::RadioSpammer::enabled);
+			ImGui::Checkbox("Timeout Vote", &Settings::Spammer::TimeoutSpammer::enabled);
+			SetTooltip("Blocks other votes from starting. Three people using this feature will continuously block votes.");
 
 			ImGui::Columns(3, NULL, true);
 			{

--- a/src/settings.h
+++ b/src/settings.h
@@ -584,6 +584,11 @@ namespace Settings
 			extern bool enabled;
 		}
 
+		namespace TimeoutSpammer
+		{
+			extern bool enabled;
+		}
+
 		namespace NormalSpammer
 		{
 			extern std::vector<std::string> messages;


### PR DESCRIPTION
If three people are using this feature, it will continuously block the enemy team from calling votes to kick each other or surrender.
It currently works, but it could still be improved by checking if the game is still in warmup or by checking if a vote is already active.