### PR TITLE
Removed Attack2 from Anti Aim

### DIFF
--- a/src/Hacks/antiaim.cpp
+++ b/src/Hacks/antiaim.cpp
@@ -270,7 +270,7 @@ void AntiAim::CreateMove(CUserCmd* cmd)
 			return;
 	}
 
-	if (cmd->buttons & IN_USE || cmd->buttons & IN_ATTACK || cmd->buttons & IN_ATTACK2)
+	if (cmd->buttons & IN_USE || cmd->buttons & IN_ATTACK)
 		return;
 
 	if (localplayer->GetMoveType() == MOVETYPE_LADDER || localplayer->GetMoveType() == MOVETYPE_NOCLIP)


### PR DESCRIPTION
Removed ATTACK2 from disabling anti aim.
Does absolutely no difference to have it there and it will problably get u killed if u zoom in at the same time that he peeks.