### PR TITLE
Implemented JumpThrow

### DIFF
--- a/src/Hacks/hacks.h
+++ b/src/Hacks/hacks.h
@@ -16,6 +16,7 @@
 #include "fakelag.h"
 #include "fovchanger.h"
 #include "hitmarkers.h"
+#include "jumpthrow.h"
 #include "namechanger.h"
 #include "namestealer.h"
 #include "noflash.h"

--- a/src/Hacks/jumpthrow.cpp
+++ b/src/Hacks/jumpthrow.cpp
@@ -1,0 +1,35 @@
+#include "jumpthrow.h"
+
+bool inAttackState = false;
+bool Settings::JumpThrow::enabled = false;
+ButtonCode_t Settings::JumpThrow::key = ButtonCode_t::KEY_T;
+
+void JumpThrow::CreateMove(CUserCmd* cmd) {
+  if(!Settings::JumpThrow::enabled)
+    return;
+
+  C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());
+
+  if(!localplayer)
+    return;
+
+  C_BaseCombatWeapon* activeWeapon = (C_BaseCombatWeapon*) entityList->GetClientEntityFromHandle(localplayer->GetActiveWeapon());
+  ItemDefinitionIndex itemDefinitionIndex = *activeWeapon->GetItemDefinitionIndex();
+
+  if (!(itemDefinitionIndex == ItemDefinitionIndex::WEAPON_FLASHBANG || itemDefinitionIndex == ItemDefinitionIndex::WEAPON_HEGRENADE || itemDefinitionIndex == ItemDefinitionIndex::WEAPON_SMOKEGRENADE || itemDefinitionIndex == ItemDefinitionIndex::WEAPON_MOLOTOV || itemDefinitionIndex == ItemDefinitionIndex::WEAPON_DECOY || itemDefinitionIndex == ItemDefinitionIndex::WEAPON_INCGRENADE))
+    return;
+
+  if (localplayer->GetMoveType() == MOVETYPE_LADDER || localplayer->GetMoveType() == MOVETYPE_NOCLIP)
+    return;
+
+  if (!inputSystem->IsButtonDown(Settings::JumpThrow::key) && !inAttackState)
+    return;
+
+  if (!inputSystem->IsButtonDown(Settings::JumpThrow::key) && inAttackState) {
+    cmd->buttons |= IN_JUMP;
+    inAttackState = false;
+    return;
+  }
+  cmd->buttons |= IN_ATTACK;
+  inAttackState = true;
+}

--- a/src/Hacks/jumpthrow.h
+++ b/src/Hacks/jumpthrow.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../SDK/SDK.h"
+#include "../interfaces.h"
+#include "../settings.h"
+#include "../Utils/entity.h"
+
+namespace JumpThrow
+{
+  void CreateMove(CUserCmd* cmd);
+}

--- a/src/Hooks/CreateMove.cpp
+++ b/src/Hooks/CreateMove.cpp
@@ -17,6 +17,7 @@ bool Hooks::CreateMove(void* thisptr, float flInputSampleTime, CUserCmd* cmd)
 		Chams::CreateMove(cmd);
 		ShowRanks::CreateMove(cmd);
 		AutoDefuse::CreateMove(cmd);
+		JumpThrow::CreateMove(cmd);
 		EdgeJump::PrePredictionCreateMove(cmd);
 
 		PredictionSystem::StartPrediction(cmd);

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -1433,6 +1433,8 @@ void MiscTab()
 					}
 				}
 				SetTooltip("Teleport to (0, 0) on any map");
+				ImGui::Checkbox("Jump Throw", &Settings::JumpThrow::enabled);
+				SetTooltip("Hold to prime grenade, release to perform perfect jump throw. Good for executing map smokes.");
 				ImGui::Checkbox("Sniper Crosshair", &Settings::SniperCrosshair::enabled);
 				SetTooltip("Enables the the crosshair with sniper rifles");
 			}
@@ -1448,6 +1450,7 @@ void MiscTab()
 				UI::KeyBindButton(&Settings::Airstuck::key);
 				UI::KeyBindButton(&Settings::Autoblock::key);
 				UI::KeyBindButton(&Settings::Teleport::key);
+				UI::KeyBindButton(&Settings::JumpThrow::key);
 			}
 			ImGui::Columns(1);
 			ImGui::Separator();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -415,6 +415,9 @@ void Settings::LoadDefaultsOrSave(std::string path)
 	settings["ThirdPerson"]["enabled"] = Settings::ThirdPerson::enabled;
 	settings["ThirdPerson"]["distance"] = Settings::ThirdPerson::distance;
 
+	settings["JumpThrow"]["enabled"] = Settings::JumpThrow::enabled;
+	settings["JumpThrow"]["key"] = Util::GetButtonName(Settings::JumpThrow::key);
+
 	std::ofstream(path) << styledWriter.write(settings);
 }
 
@@ -812,6 +815,9 @@ void Settings::LoadConfig(std::string path)
 
 	GetVal(settings["ThirdPerson"]["enabled"], &Settings::ThirdPerson::enabled);
 	GetVal(settings["ThirdPerson"]["distance"], &Settings::ThirdPerson::distance);
+
+	GetVal(settings["JumpThrow"]["enabled"], &Settings::JumpThrow::enabled);
+	GetButtonCode(settings["JumpThrow"]["key"], &Settings::JumpThrow::key);
 }
 
 void Settings::LoadSettings()

--- a/src/settings.h
+++ b/src/settings.h
@@ -805,6 +805,12 @@ namespace Settings
 		extern float distance;
 	}
 
+	namespace JumpThrow
+	{
+		extern bool enabled;
+		extern ButtonCode_t key;
+	}
+
 	void LoadDefaultsOrSave(std::string path);
 	void LoadConfig(std::string path);
 	void LoadSettings();


### PR DESCRIPTION
This basically allows the user to set a custom key and enable/disable a feature that executes a perfect jump throw. This is good for map smokes. There are already console binds for this online, but I thought that it would be convenient to have it built in to the misc. tab anyways. Besides, this adds more functionality to it:

- It checks if the user is holding a grenade or not.
- Allows for easy custom keybinding
- Quick toggling via GUI