### PR TITLE
Some visual hacks not checking if the Visual Category was enabled

### DIFF
--- a/src/Hacks/asuswalls.cpp
+++ b/src/Hacks/asuswalls.cpp
@@ -47,7 +47,7 @@ void ASUSWalls::FrameStageNotify(ClientFrameStage_t stage)
 			worldMaterials2.emplace(i, ImColor(r, g, b, a));
 		}
 
-		ImColor color = Settings::ASUSWalls::enabled ? Settings::ASUSWalls::color : worldMaterials2.find(i)->second;
+		ImColor color = (Settings::ESP::enabled && Settings::ASUSWalls::enabled) ? Settings::ASUSWalls::color : worldMaterials2.find(i)->second;
 
 		if (worldMaterials.at(i) != color)
 		{

--- a/src/Hacks/asuswalls.cpp
+++ b/src/Hacks/asuswalls.cpp
@@ -47,7 +47,7 @@ void ASUSWalls::FrameStageNotify(ClientFrameStage_t stage)
 			worldMaterials2.emplace(i, ImColor(r, g, b, a));
 		}
 
-		ImColor color = (Settings::ESP::enabled && Settings::ASUSWalls::enabled) ? Settings::ASUSWalls::color : worldMaterials2.find(i)->second;
+		ImColor color = (Settings::ASUSWalls::enabled && Settings::ESP::enabled) ? Settings::ASUSWalls::color : worldMaterials2.find(i)->second;
 
 		if (worldMaterials.at(i) != color)
 		{

--- a/src/Hacks/noflash.cpp
+++ b/src/Hacks/noflash.cpp
@@ -15,7 +15,7 @@ void Noflash::FrameStageNotify(ClientFrameStage_t stage)
 	if (!localplayer)
 		return;
 
-	if (Settings::Noflash::enabled)
+	if (Settings::Noflash::enabled && Settings::ESP::enabled)
 		*localplayer->GetFlashMaxAlpha() = 255.0f - Settings::Noflash::value;
 	else
 		*localplayer->GetFlashMaxAlpha() = 255.0f;

--- a/src/Hacks/nosky.cpp
+++ b/src/Hacks/nosky.cpp
@@ -47,7 +47,7 @@ void NoSky::FrameStageNotify(ClientFrameStage_t stage)
 			skyboxMaterials2.emplace(i, ImColor(r1, g1, b1, a1));
 		}
 
-		ImColor color = (Settings::ESP::enabled && Settings::NoSky::enabled) ? Settings::NoSky::color : skyboxMaterials2.find(i)->second;
+		ImColor color = (Settings::NoSky::enabled && Settings::ESP::enabled) ? Settings::NoSky::color : skyboxMaterials2.find(i)->second;
 
 		if (skyboxMaterials.at(i) != color)
 		{

--- a/src/Hacks/nosky.cpp
+++ b/src/Hacks/nosky.cpp
@@ -47,7 +47,7 @@ void NoSky::FrameStageNotify(ClientFrameStage_t stage)
 			skyboxMaterials2.emplace(i, ImColor(r1, g1, b1, a1));
 		}
 
-		ImColor color = Settings::NoSky::enabled ? Settings::NoSky::color : skyboxMaterials2.find(i)->second;
+		ImColor color = (Settings::ESP::enabled && Settings::NoSky::enabled) ? Settings::NoSky::color : skyboxMaterials2.find(i)->second;
 
 		if (skyboxMaterials.at(i) != color)
 		{

--- a/src/Hacks/view.cpp
+++ b/src/Hacks/view.cpp
@@ -8,7 +8,7 @@ QAngle old_aim_punch_angle;
 
 void View::FrameStageNotify(ClientFrameStage_t stage)
 {
-	if (!Settings::View::NoAimPunch::enabled && !Settings::View::NoViewPunch::enabled)
+	if ((!Settings::View::NoAimPunch::enabled && !Settings::View::NoViewPunch::enabled) || !Settings::ESP::enabled)
 		return;
 
 	if (!engine->IsInGame())
@@ -48,7 +48,7 @@ void View::FrameStageNotify(ClientFrameStage_t stage)
 
 void View::PostFrameStageNotify(ClientFrameStage_t stage)
 {
-	if (!Settings::View::NoAimPunch::enabled && !Settings::View::NoViewPunch::enabled)
+	if ((!Settings::View::NoAimPunch::enabled && !Settings::View::NoViewPunch::enabled) || !Settings::ESP::enabled)
 		return;
 
 	if (!engine->IsInGame())


### PR DESCRIPTION
Most of the visual hacks check if the Visual category is on before they work. However some do not.

This is useful because you can turn off all of the visual hacks at once by disabling the visual category. 