### PR TITLE
Adaptive FakeLag

### DIFF
--- a/src/Hacks/fakelag.cpp
+++ b/src/Hacks/fakelag.cpp
@@ -39,8 +39,8 @@ void FakeLag::CreateMove(CUserCmd* cmd)
 			if (localplayer->GetVelocity().Length() > 0.f)
 			{
 				packetsToChoke = (int)((64.f / globalVars->interval_per_tick) / localplayer->GetVelocity().Length()) + 1;
-				if (packetsToChoke > 16)
-					packetsToChoke = 16;
+				if (packetsToChoke >= 15)
+					packetsToChoke = 14;
 				if (packetsToChoke < Settings::FakeLag::value)
 					packetsToChoke = Settings::FakeLag::value;
 			}

--- a/src/Hacks/fakelag.cpp
+++ b/src/Hacks/fakelag.cpp
@@ -38,7 +38,7 @@ void FakeLag::CreateMove(CUserCmd* cmd)
 			int packetsToChoke;
 			if (localplayer->GetVelocity().Length() > 0.f)
 			{
-				packetsToChoke = (int)(4096.f / localplayer->GetVelocity().Length()) + 1;
+				packetsToChoke = (int)((64.f / globalVars->interval_per_tick) / localplayer->GetVelocity().Length()) + 1;
 				if (packetsToChoke > 16)
 					packetsToChoke = 16;
 				if (packetsToChoke < Settings::FakeLag::value)

--- a/src/Hacks/fakelag.cpp
+++ b/src/Hacks/fakelag.cpp
@@ -17,7 +17,7 @@ void FakeLag::CreateMove(CUserCmd* cmd)
 	if (!localplayer || !localplayer->GetAlive())
 		return;
 
-	if (localplayer->GetFlags() & FL_ONGROUND)
+	if (localplayer->GetFlags() & FL_ONGROUND && Settings::FakeLag::adaptive)
 		return;
 
 	if (cmd->buttons & IN_ATTACK)

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -1038,7 +1038,7 @@ void HvHTab()
 		ImGui::BeginChild("HVH1", ImVec2(0, 0), true);
 		{
 			ImGui::Text("AntiAim");
-			ImGui::BeginChild("##ANTIAIM", ImVec2(0, ImGui::GetWindowSize().y / 2 + 64), true);
+			ImGui::BeginChild("##ANTIAIM", ImVec2(0, 0), true);
 			{
 				ImGui::Checkbox("Yaw", &Settings::AntiAim::Yaw::enabled);
 				SetTooltip("Enables Yaw AntiAim");

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -1038,7 +1038,7 @@ void HvHTab()
 		ImGui::BeginChild("HVH1", ImVec2(0, 0), true);
 		{
 			ImGui::Text("AntiAim");
-			ImGui::BeginChild("##ANTIAIM", ImVec2(0, 0), true);
+			ImGui::BeginChild("##ANTIAIM", ImVec2(0, ImGui::GetWindowSize().y / 2 + 64), true);
 			{
 				ImGui::Checkbox("Yaw", &Settings::AntiAim::Yaw::enabled);
 				SetTooltip("Enables Yaw AntiAim");
@@ -1452,6 +1452,8 @@ void MiscTab()
 			{
 				ImGui::Checkbox("Fake Lag", &Settings::FakeLag::enabled);
 				SetTooltip("Chokes packets so it appears you're lagging");
+				ImGui::Checkbox("Adaptive Fake Lag", &Settings::FakeLag::adaptive);
+				SetTooltip("Chokes packets based on velocity (minimum choked is fakelag value)");
 				ImGui::Checkbox("Auto Accept", &Settings::AutoAccept::enabled);
 				SetTooltip("Auto accept games when in MM queue");
 				ImGui::Checkbox("Auto Defuse", &Settings::AutoDefuse::enabled);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -394,6 +394,7 @@ void Settings::LoadDefaultsOrSave(std::string path)
 
 	settings["FakeLag"]["enabled"] = Settings::FakeLag::enabled;
 	settings["FakeLag"]["value"] = Settings::FakeLag::value;
+	settings["FakeLag"]["adaptive"] = Settings::FakeLag::adaptive;
 
 	settings["AutoAccept"]["enabled"] = Settings::AutoAccept::enabled;
 
@@ -804,6 +805,7 @@ void Settings::LoadConfig(std::string path)
 
 	GetVal(settings["FakeLag"]["enabled"], &Settings::FakeLag::enabled);
 	GetVal(settings["FakeLag"]["value"], &Settings::FakeLag::value);
+	GetVal(settings["FakeLag"]["adaptive"], &Settings::FakeLag::adaptive);
 
 	GetVal(settings["AutoAccept"]["enabled"], &Settings::AutoAccept::enabled);
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -756,6 +756,7 @@ namespace Settings
 	{
 		extern bool enabled;
 		extern int value;
+		extern bool adaptive;
 	}
 
 	namespace AutoAccept


### PR DESCRIPTION
Also disabled fakelag when onground because you would have to be choking 17 packets for it to break lag compensation when running with the knife and changed the default value to 9.