### PR TITLE
Show friendly decoy owner

### DIFF
--- a/src/Hacks/esp.cpp
+++ b/src/Hacks/esp.cpp
@@ -4,6 +4,7 @@
 #include "../Utils/skins.h"
 
 bool Settings::ESP::enabled = false;
+bool Settings::ESP::decoyShowOwner = false;
 TeamColorType Settings::ESP::teamColorType = TeamColorType::RELATIVE;
 ImColor Settings::ESP::enemyColor = ImColor(240, 60, 60, 255);
 ImColor Settings::ESP::enemyVisibleColor = ImColor(240, 185, 60, 255);
@@ -810,8 +811,11 @@ void ESP::DrawThrowable(C_BaseEntity* throwable, ClientClass* client)
 		else if (strstr(mat->GetName(), "decoy"))
 		{
 			nadeName = "Decoy";
-			nadeColor = Settings::ESP::decoyColor;			
+			nadeColor = Settings::ESP::decoyColor;
 			
+			if (!Settings::ESP::decoyShowOwner)
+				break;
+
 			C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());
 			if (!localplayer)
 				break;

--- a/src/Hacks/esp.cpp
+++ b/src/Hacks/esp.cpp
@@ -801,16 +801,40 @@ void ESP::DrawThrowable(C_BaseEntity* throwable, ClientClass* client)
 			nadeColor = Settings::ESP::smokeColor;
 			break;
 		}
-		else if (strstr(mat->GetName(), "decoy"))
-		{
-			nadeName = "Decoy";
-			nadeColor = Settings::ESP::decoyColor;
-			break;
-		}
 		else if (strstr(mat->GetName(), "incendiary") || strstr(mat->GetName(), "molotov"))
 		{
 			nadeName = "Molotov";
 			nadeColor = Settings::ESP::molotovColor;
+			break;
+		}
+		else if (strstr(mat->GetName(), "decoy"))
+		{
+			nadeName = "Decoy";
+			
+			C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());
+			if (!localplayer)
+				break;
+			
+			if (throwable->GetTeam() == localplayer->GetTeam())
+			{
+				nadeColor = Settings::ESP::allyColor;
+
+				int owner = throwable->GetOwnerEntity() & 0xFFF;
+				if (!owner)
+					break;
+
+				IEngineClient::player_info_t entityInformation;
+				engine->GetPlayerInfo(owner, &entityInformation);
+
+				nadeName += "(";
+				nadeName += entityInformation.name;
+				nadeName += ")";
+			}
+			else
+			{
+				nadeColor = Settings::ESP::decoyColor;			
+			}
+
 			break;
 		}
 	}

--- a/src/Hacks/esp.cpp
+++ b/src/Hacks/esp.cpp
@@ -810,6 +810,7 @@ void ESP::DrawThrowable(C_BaseEntity* throwable, ClientClass* client)
 		else if (strstr(mat->GetName(), "decoy"))
 		{
 			nadeName = "Decoy";
+			nadeColor = Settings::ESP::decoyColor;			
 			
 			C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());
 			if (!localplayer)
@@ -817,8 +818,6 @@ void ESP::DrawThrowable(C_BaseEntity* throwable, ClientClass* client)
 			
 			if (throwable->GetTeam() == localplayer->GetTeam())
 			{
-				nadeColor = Settings::ESP::allyColor;
-
 				int owner = throwable->GetOwnerEntity() & 0xFFF;
 				if (!owner)
 					break;
@@ -829,10 +828,6 @@ void ESP::DrawThrowable(C_BaseEntity* throwable, ClientClass* client)
 				nadeName += "(";
 				nadeName += entityInformation.name;
 				nadeName += ")";
-			}
-			else
-			{
-				nadeColor = Settings::ESP::decoyColor;			
 			}
 
 			break;

--- a/src/SDK/IClientEntity.h
+++ b/src/SDK/IClientEntity.h
@@ -179,6 +179,11 @@ public:
 	{
 		return *(TeamID*)((uintptr_t)this + offsets.DT_BaseEntity.m_iTeamNum);
 	}
+  
+	int GetOwnerEntity()
+	{
+		return *(int*)((uintptr_t)this + offsets.DT_BaseEntity.m_hOwnerEntity);
+	}
 
 	Vector GetVecOrigin()
 	{

--- a/src/offsets.cpp
+++ b/src/offsets.cpp
@@ -30,6 +30,7 @@ void Offsets::GetOffsets()
 	offsets.DT_BaseEntity.m_MoveType = offsets.DT_BaseEntity.m_nRenderMode + 1;
 	offsets.DT_BaseEntity.m_Collision = NetVarManager::GetOffset(tables, "DT_BaseEntity", "m_Collision");
 	offsets.DT_BaseEntity.m_bSpotted = NetVarManager::GetOffset(tables, "DT_BaseEntity", "m_bSpotted");
+	offsets.DT_BaseEntity.m_hOwnerEntity = NetVarManager::GetOffset(tables, "DT_BaseEntity", "m_hOwnerEntity");
 
 	offsets.DT_BaseCombatCharacter.m_hActiveWeapon = NetVarManager::GetOffset(tables, "DT_BaseCombatCharacter", "m_hActiveWeapon");
 	offsets.DT_BaseCombatCharacter.m_hMyWeapons = NetVarManager::GetOffset(tables, "DT_BaseCombatCharacter", "m_hMyWeapons") / 2;

--- a/src/offsets.h
+++ b/src/offsets.h
@@ -33,6 +33,7 @@ struct COffsets
 		std::ptrdiff_t m_MoveType;
 		std::ptrdiff_t m_Collision;
 		std::ptrdiff_t m_bSpotted;
+		std::ptrdiff_t m_hOwnerEntity;
 	} DT_BaseEntity;
 
 	struct

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -170,6 +170,7 @@ void Settings::LoadDefaultsOrSave(std::string path)
 	settings["AntiAim"]["AutoDisable"]["knife_held"] = Settings::AntiAim::AutoDisable::knifeHeld;
 
 	settings["ESP"]["enabled"] = Settings::ESP::enabled;
+	settings["ESP"]["decoy_show_owner"] = Settings::ESP::decoyShowOwner;
 	LoadUIColor(settings["ESP"]["enemy_color"], Settings::ESP::enemyColor);
 	LoadUIColor(settings["ESP"]["enemy_visible_color"], Settings::ESP::enemyVisibleColor);
 	LoadUIColor(settings["ESP"]["ally_color"], Settings::ESP::allyColor);
@@ -566,6 +567,7 @@ void Settings::LoadConfig(std::string path)
 	GetVal(settings["AntiAim"]["AutoDisable"]["no_enemy"], &Settings::AntiAim::AutoDisable::noEnemy);
 
 	GetVal(settings["ESP"]["enabled"], &Settings::ESP::enabled);
+	GetVal(settings["ESP"]["decoy_show_owner"], &Settings::ESP::decoyShowOwner);
 	GetVal(settings["ESP"]["enemy_color"], &Settings::ESP::enemyColor);
 	GetVal(settings["ESP"]["enemy_visible_color"], &Settings::ESP::enemyVisibleColor);
 	GetVal(settings["ESP"]["ally_color"], &Settings::ESP::allyColor);

--- a/src/settings.h
+++ b/src/settings.h
@@ -436,6 +436,7 @@ namespace Settings
 	namespace ESP
 	{
 		extern bool enabled;
+		extern bool decoyShowOwner;
 		extern TeamColorType teamColorType;
 		extern ImColor enemyColor;
 		extern ImColor allyColor;


### PR DESCRIPTION
Implemented it because it's pretty useful to know who are you getting teamkills for when killing yourself with decoy.
Only problem I have noticed so far is that when player disconnects the name field will be empty and I'm not really sure what's the best way to check if owner is still in game.