### PR TITLE
Pass path into grep instead of using cat

### DIFF
--- a/rload
+++ b/rload
@@ -2,5 +2,5 @@
 
 sudo ./uload
 cmake .
-make -j$(cat /proc/cpuinfo | grep "^processor" | wc -l) "$@"
+make -j$(grep "^processor" /proc/cpuinfo | wc -l) "$@"
 sudo ./load

--- a/update
+++ b/update
@@ -6,5 +6,5 @@ else
     git pull
     git submodule update --init --recursive --remote
     cmake .
-    make -j$(cat /proc/cpuinfo | grep "^processor" | wc -l) "$@"
+    make -j$(grep "^processor" /proc/cpuinfo | wc -l) "$@"
 fi


### PR DESCRIPTION
grep should be given the filename directly instead of using cat to pass the file contents.

Using cat is just a waste of performance!