### PR TITLE
Added .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+#AimTux clang-format
+BasedOnStyle: WebKit
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+PointerAlignment: Left
+IndentCaseLabels: false
+#ColumnLimit: 0
+UseTab: Always


### PR DESCRIPTION
Added a .clang-format file with the specifications for AimTux coding style. 
This should make the code look a lot cleaner along with giving a truly universal formatting style for AimTux.
It also allows other users to use their own .clang-formats while they're coding then change back to the AimTux clang.

I plan on mass formatting the existing code after this gets reviewed. Those folders are as follows:
src/Hacks/*
src/ATGUI/*

But exclude any files in the root of src/ for the sake of having it already well formatted. Also, no SDK, tools, or ImGUI should be formatted. 

I can write a script to apply the discriminant formatting for all to use if approved. 