### PR TITLE
Adding Strafe Key

### DIFF
--- a/src/ATGUI/Tabs/misctab.cpp
+++ b/src/ATGUI/Tabs/misctab.cpp
@@ -45,9 +45,19 @@ void Misc::RenderTab()
 			}
 
 			if (Settings::AutoStrafe::type == AutostrafeType::AS_RAGE)
+                        {
+                                ImGui::Checkbox("Silent", &Settings::AutoStrafe::silent);
+                                SetTooltip("Strafes won't be visible for spectators");
+                        }
+
+			ImGui::Columns(2, NULL, true);
 			{
-				ImGui::Checkbox("Silent", &Settings::AutoStrafe::silent);
-				SetTooltip("Strafes won't be visible for spectators");
+				ImGui::Checkbox("Strafe Key", &Settings::AutoStrafe::StrafeKey::enabled);
+				SetTooltip("Strafes only when a key is held");
+			}
+			ImGui::NextColumn();
+			{
+				UI::KeyBindButton(&Settings::AutoStrafe::StrafeKey::key);
 			}
 
 			ImGui::Columns(1);

--- a/src/Hacks/autostrafe.cpp
+++ b/src/Hacks/autostrafe.cpp
@@ -3,6 +3,8 @@
 bool Settings::AutoStrafe::enabled = false;
 AutostrafeType Settings::AutoStrafe::type = AutostrafeType::AS_FORWARDS;
 bool Settings::AutoStrafe::silent = true;
+bool Settings::AutoStrafe::StrafeKey::enabled = false;
+ButtonCode_t Settings::AutoStrafe::StrafeKey::key = ButtonCode_t::KEY_LSHIFT;
 
 void LegitStrafe(C_BasePlayer* localplayer, CUserCmd* cmd)
 {
@@ -81,6 +83,8 @@ void RageStrafe(C_BasePlayer* localplayer, CUserCmd* cmd)
 void AutoStrafe::CreateMove(CUserCmd* cmd)
 {
 	if (!Settings::AutoStrafe::enabled)
+		return;
+	if (Settings::AutoStrafe::StrafeKey::enabled && !inputSystem->IsButtonDown(Settings::AutoStrafe::StrafeKey::key))
 		return;
 
 	C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -734,8 +734,10 @@ void Settings::LoadConfig(std::string path)
 	GetVal(settings["AutoStrafe"]["enabled"], &Settings::AutoStrafe::enabled);
 	GetVal(settings["AutoStrafe"]["type"], (int*)& Settings::AutoStrafe::type);
 	GetVal(settings["AutoStrafe"]["silent"], &Settings::AutoStrafe::silent);
+	
 	GetVal(settings["AutoStrafe"]["StrafeKey"]["enabled"], &Settings::AutoStrafe::StrafeKey::enabled);
 	GetButtonCode(settings["AutoStrafe"]["StrafeKey"]["key"], &Settings::AutoStrafe::StrafeKey::key);
+	
 	GetVal(settings["Noflash"]["enabled"], &Settings::Noflash::enabled);
 	GetVal(settings["Noflash"]["value"], &Settings::Noflash::value);
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -345,6 +345,8 @@ void Settings::LoadDefaultsOrSave(std::string path)
 	settings["AutoStrafe"]["enabled"] = Settings::AutoStrafe::enabled;
 	settings["AutoStrafe"]["type"] = (int) Settings::AutoStrafe::type;
 	settings["AutoStrafe"]["silent"] = Settings::AutoStrafe::silent;
+        settings["AutoStrafe"]["StrafeKey"]["enabled"] = Settings::AutoStrafe::StrafeKey::enabled;
+        settings["AutoStrafe"]["StrafeKey"]["key"] = Util::GetButtonName(Settings::AutoStrafe::StrafeKey::key);
 
 	settings["Noflash"]["enabled"] = Settings::Noflash::enabled;
 	settings["Noflash"]["value"] = Settings::Noflash::value;
@@ -732,7 +734,8 @@ void Settings::LoadConfig(std::string path)
 	GetVal(settings["AutoStrafe"]["enabled"], &Settings::AutoStrafe::enabled);
 	GetVal(settings["AutoStrafe"]["type"], (int*)& Settings::AutoStrafe::type);
 	GetVal(settings["AutoStrafe"]["silent"], &Settings::AutoStrafe::silent);
-
+	GetVal(settings["AutoStrafe"]["StrafeKey"]["enabled"], &Settings::AutoStrafe::StrafeKey::enabled);
+	GetButtonCode(settings["AutoStrafe"]["StrafeKey"]["key"], &Settings::AutoStrafe::StrafeKey::key);
 	GetVal(settings["Noflash"]["enabled"], &Settings::Noflash::enabled);
 	GetVal(settings["Noflash"]["value"], &Settings::Noflash::value);
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -701,6 +701,12 @@ namespace Settings
 		extern bool enabled;
 		extern AutostrafeType type;
 		extern bool silent;
+
+		namespace StrafeKey
+		{
+			extern bool enabled;
+			extern ButtonCode_t key;
+		}
 	}
 
 	namespace Noflash


### PR DESCRIPTION
The commits are pretty self-explanatory. When the check box is selected, you will only strafe when holding the desired key (defaulted to left shift).

The changes on misctab.cpp look a little funny because I accidentally programmed it out of order.